### PR TITLE
fix mem allocation and DataSpace

### DIFF
--- a/src/libPMacc/include/dimensions/DataSpace.hpp
+++ b/src/libPMacc/include/dimensions/DataSpace.hpp
@@ -83,7 +83,7 @@ namespace PMacc
         template<
             typename TDim,
             typename TVal,
-            typename = typename std::enable_if<(TDim::value > DIM)>::type>
+            typename = typename std::enable_if<(TDim::value == DIM)>::type>
         HDINLINE DataSpace(
             alpaka::Vec<TDim, TVal> const & vec)
         {

--- a/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
+++ b/src/libPMacc/include/memory/buffers/DeviceBufferIntern.hpp
@@ -26,6 +26,7 @@
 #include "eventSystem/tasks/Factory.hpp"
 #include "memory/buffers/DeviceBuffer.hpp"
 #include "memory/boxes/DataBox.hpp"
+#include "algorithms/TypeCast.hpp"
 
 #include <alpaka/alpaka.hpp>
 
@@ -242,7 +243,8 @@ private:
 
         return alpaka::mem::buf::alloc<TYPE, std::size_t>(
             Environment<>::get().DeviceManager().getDevice(),
-            this->getDataSpace());
+            algorithms::precisionCast::precisionCast<std::size_t>(this->getDataSpace())
+            );
     }
 
     /*! Creates a ND-buffer without pitch.
@@ -257,7 +259,8 @@ private:
         DataBufDev buf(
             alpaka::mem::buf::alloc<TYPE, std::size_t>(
                 Environment<>::get().DeviceManager().getDevice(),
-                this->getDataSpace()));
+                algorithms::precisionCast::precisionCast<std::size_t>(this->getDataSpace())
+            ));
 
         using MemBufFake = alpaka::mem::buf::Buf<
             AlpakaDev,


### PR DESCRIPTION
- only allowed to copy DataSpace if dimension of alpaka and PMacc size type is equel
- explizit cast to `std::size_t` for extents
