### PR TITLE
refactor PMacc event system

### DIFF
--- a/src/libPMacc/examples/gameOfLife2D/include/Simulation.hpp
+++ b/src/libPMacc/examples/gameOfLife2D/include/Simulation.hpp
@@ -145,10 +145,10 @@ public:
         // in units of SuperCells to be used by the kernel to identify itself.
         evo.init(
             MappingDesc(layout.getDataSpace(), 1, 1));
-            
+
         buff1.reset(new PMacc::GridBuffer<std::uint8_t, DIM2>(layout, false));
         buff2.reset(new PMacc::GridBuffer<std::uint8_t, DIM2>(layout, false));
-            
+
         PMacc::DataSpace<DIM2> guardingCells(1, 1);
         for (uint32_t i(1); i < PMacc::traits::NumberOfExchanges<DIM2>::value; ++i)
         {
@@ -161,7 +161,7 @@ public:
             buff1->addExchange(PMacc::GUARD, PMacc::Mask(i), guardingCells, BUFF1);
             buff2->addExchange(PMacc::GUARD, PMacc::Mask(i), guardingCells, BUFF2);
         }
-            
+
         // Both next lines are defined in GatherSlice.hpp:
         // -gather saves the MessageHeader object
         // -Then do an Allgather for the gloabalRanks from GC, sort out
@@ -236,7 +236,7 @@ private:
         evo.run<PMacc::BORDER>(
             read.getDeviceBuffer().getDataBox(),
             write.getDeviceBuffer().getDataBox());
-            
+
         // Copy from device to host for saving. All threads and not only the master have to do this.
         write.deviceToHost();
 
@@ -264,7 +264,7 @@ private:
             writeFullImage(write, sFileNameWithoutExt);
         }
     }
-        
+
     //-----------------------------------------------------------------------------
     //!
     //-----------------------------------------------------------------------------

--- a/src/libPMacc/include/eventSystem/streams/EventStream.hpp
+++ b/src/libPMacc/include/eventSystem/streams/EventStream.hpp
@@ -43,7 +43,7 @@ public:
      * Creates the cudaStream_t object.
      */
     EventStream(alpaka::dev::Dev<AlpakaAccDev> dev) :
-        stream(dev)
+        stream(new AlpakaAccStream(dev))
     {}
 
     /**
@@ -53,28 +53,28 @@ public:
     virtual ~EventStream()
     {
         //wait for all kernels in stream to finish
-        alpaka::wait::wait(stream);
+        alpaka::wait::wait(*stream);
     }
 
     /**
      * Returns the cudaStream_t object associated with this EventStream.
      * @return the internal cuda stream object
      */
-    AlpakaAccStream & getCudaStream()
+    AlpakaAccStream& getCudaStream()
     {
-        return stream;
+        return *stream;
     }
 
     void waitOn(const CudaEvent& ev)
     {
         if(getCudaStream() != ev.getCudaStream())
         {
-            alpaka::wait::wait(stream, *ev);
+            alpaka::wait::wait(*stream, *ev);
         }
     }
 
 private:
-    AlpakaAccStream stream;
+    AlpakaAccStream* stream;
 };
 
 }

--- a/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
+++ b/src/libPMacc/include/eventSystem/tasks/StreamTask.hpp
@@ -98,8 +98,9 @@ namespace PMacc
 
     private:
         mutable EventStream* stream;
-        std::unique_ptr<CudaEvent> cudaEvent;
+        CudaEvent cudaEvent;
         bool alwaysFinished;
+        bool hasCudaEvent;
     };
 
 } //namespace PMacc

--- a/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
+++ b/src/libPMacc/include/particles/memory/boxes/ParticlesBox.hpp
@@ -80,6 +80,7 @@ public:
      *
      * @return an empty frame
      */
+    PMACC_NO_NVCC_HDWARNING
     DINLINE FRAME &getEmptyFrame() const
     {
 
@@ -87,7 +88,7 @@ public:
         const int maxTries = 13; //magic number is not performance critical
         for (int numTries = 0; numTries < maxTries; ++numTries)
         {
-            tmp = (FrameType*) mallocMC::malloc(sizeof (FrameType));
+            tmp = (FrameType*) ::mallocMC::malloc(sizeof (FrameType));
             if (tmp != NULL)
             {
                 /* disable all particles since we can not assume that newly allocated memory contains zeros */
@@ -119,7 +120,7 @@ public:
      */
     DINLINE void removeFrame(FRAME &frame) const
     {
-        mallocMC::free((void*) &frame);
+        ::mallocMC::free((void*) &frame);
     }
 
     HDINLINE

--- a/src/libPMacc/include/types.h
+++ b/src/libPMacc/include/types.h
@@ -51,11 +51,12 @@ namespace PMacc
     using AlpakaHostDev = alpaka::dev::DevCpu;
 #ifdef PMACC_ACC_CPU
     using AlpakaAccDev = alpaka::dev::DevCpu;
-    //using AlpakaAccStream = alpaka::stream::StreamCpuAsync;
-    using AlpakaAccStream = alpaka::stream::StreamCpuSync;
+    using AlpakaAccStream = alpaka::stream::StreamCpuAsync;
+    //using AlpakaAccStream = alpaka::stream::StreamCpuSync;
     template<
         typename TDim>
     using AlpakaAcc = alpaka::acc::AccCpuOmp2Threads<TDim, AlpakaIdxSize>;
+    //using AlpakaAcc = alpaka::acc::AccCpuOmp2Blocks<TDim, AlpakaIdxSize>;
 #else
     using AlpakaAccDev = alpaka::dev::DevCudaRt;
     using AlpakaAccStream = alpaka::stream::StreamCudaRtAsync;

--- a/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/RandomPositionImpl.hpp
@@ -50,6 +50,7 @@ struct RandomPositionImpl
         localCells = subGrid.getLocalDomain().size;
     }
 
+    PMACC_NO_NVCC_HDWARNING
     template<
         typename T_Acc,
         typename T_Particle1,

--- a/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
+++ b/src/picongpu/include/particles/manipulators/TemperatureImpl.hpp
@@ -58,6 +58,7 @@ struct TemperatureImpl : private T_ValueFunctor
         localCells = subGrid.getLocalDomain().size;
     }
 
+    PMACC_NO_NVCC_HDWARNING
     template<
         typename T_Acc,
         typename T_Particle1,

--- a/src/picongpu/include/particles/startPosition/RandomImpl.hpp
+++ b/src/picongpu/include/particles/startPosition/RandomImpl.hpp
@@ -77,6 +77,7 @@ struct RandomImpl
      * @param curParticle the number of this particle: [0, totalNumParsPerCell-1]
      * @return float3_X with components between [0.0, 1.0)
      */
+    PMACC_NO_NVCC_HDWARNING
     DINLINE floatD_X operator()(const uint32_t)
     {
         floatD_X result;

--- a/thirdParty/mallocMC/src/include/mallocMC/DistributionPolicies.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/DistributionPolicies.hpp
@@ -34,7 +34,6 @@
 
 #if defined(MAMC_CUDA_ENABLED) && defined(__CUDACC__)
 
-
 #include "distributionPolicies/XMallocSIMD.hpp"
 #include "distributionPolicies/XMallocSIMD_impl.hpp"
 

--- a/thirdParty/mallocMC/src/include/mallocMC/ReservePoolPolicies.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/ReservePoolPolicies.hpp
@@ -34,7 +34,6 @@
 
 #if defined(MAMC_CUDA_ENABLED) && defined(__CUDACC__)
 
-
 #include "reservePoolPolicies/SimpleCudaMalloc.hpp"
 #include "reservePoolPolicies/SimpleCudaMalloc_impl.hpp"
 

--- a/thirdParty/mallocMC/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/alignmentPolicies/Noop_impl.hpp
@@ -41,15 +41,17 @@ namespace AlignmentPolicies{
 
     public:
 
+    MAMC_HOST
     static boost::tuple<void*,size_t> alignPool(void* memory, size_t memsize){
       return boost::make_tuple(memory,memsize);
     }
 
-    MAMC_HOST MAMC_ACCELERATOR
+    MAMC_ACC
     static uint32 applyPadding(uint32 bytes){
       return bytes;
     }
 
+    MAMC_HOST
     static std::string classname(){
       return "Noop";
     }

--- a/thirdParty/mallocMC/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/alignmentPolicies/Shrink_impl.hpp
@@ -79,6 +79,7 @@ namespace Shrink2NS{
     BOOST_STATIC_ASSERT(dataAlignment && !(dataAlignment & (dataAlignment-1)) ); 
 
     public:
+    MAMC_HOST
     static boost::tuple<void*,size_t> alignPool(void* memory, size_t memsize){
       PointerEquivalent alignmentstatus = ((PointerEquivalent)memory) & (dataAlignment -1);
       if(alignmentstatus != 0)
@@ -102,8 +103,7 @@ namespace Shrink2NS{
       return boost::make_tuple(memory,memsize);
     }
 
-    MAMC_HOST
-    MAMC_ACCELERATOR
+    MAMC_ACC
     static uint32 applyPadding(uint32 bytes){
       return (bytes + dataAlignment - 1) & ~(dataAlignment-1);
     }

--- a/thirdParty/mallocMC/src/include/mallocMC/creationPolicies/HostNew_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/creationPolicies/HostNew_impl.hpp
@@ -46,41 +46,39 @@ class HostNew
 public:
     typedef boost::mpl::bool_<false> providesAvailableSlots;
 
+    MAMC_HOST
     void* create(uint32 bytes)
     {
       return reinterpret_cast<void*>(new uint8[bytes]);
     }
 
+    MAMC_HOST
     void destroy(void* mem)
     {
         delete[] reinterpret_cast<uint8*> (mem);
     }
 
+    MAMC_HOST
     bool isOOM( void* p, size_t s )
     {
         return s && (p == NULL);
     }
 
     template < typename T>
+    MAMC_HOST
     static void* initHeap( const T& obj, void* pool, size_t memsize )
     {
-
-        try
-        {
-            return const_cast<void *> (reinterpret_cast<void const *> (&obj));
-        }
-        catch ( std::bad_alloc& exc )
-        {
-            std::cout << "error:" << exc.what( ) << std::endl;
-        };
+        return const_cast<void *> (reinterpret_cast<void const *> (&obj));
     }
 
     template < typename T>
+    MAMC_HOST
     static void finalizeHeap( const T& obj, void* pool )
     {
         return;
     }
 
+    MAMC_HOST
     static std::string classname( )
     {
         return "HostNew";

--- a/thirdParty/mallocMC/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/creationPolicies/OldMalloc_impl.hpp
@@ -42,32 +42,38 @@ namespace CreationPolicies{
     public:
     typedef boost::mpl::bool_<false> providesAvailableSlots;
 
-    __device__ void* create(uint32 bytes)
+    MAMC_ACC_CUDA_ONLY
+    void* create(uint32 bytes)
     {
       return ::malloc(static_cast<size_t>(bytes));
     }
 
-    __device__ void destroy(void* mem)
+    MAMC_ACC_CUDA_ONLY
+    void destroy(void* mem)
     {
-      free(mem);
+      ::free(mem);
     }
 
-    __device__ bool isOOM(void* p, size_t s){
+    MAMC_ACC_CUDA_ONLY
+    bool isOOM(void* p, size_t s){
       return s && (p == NULL);
     }
 
     template < typename T>
+    MAMC_HOST
     static void* initHeap(const T& obj, void* pool, size_t memsize){
       T* dAlloc;
       MALLOCMC_CUDA_CHECKED_CALL(cudaGetSymbolAddress((void**)&dAlloc,obj));
       return dAlloc;
     }   
 
+    MAMC_HOST
     template < typename T>
     static void finalizeHeap(const T& obj, void* pool){
       return;
     }
 
+    MAMC_HOST
     static std::string classname(){
       return "OldMalloc";
     }

--- a/thirdParty/mallocMC/src/include/mallocMC/distributionPolicies/Noop_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/distributionPolicies/Noop_impl.hpp
@@ -42,16 +42,17 @@ namespace DistributionPolicies{
 
     public:
 
-    MAMC_ACCELERATOR
+    MAMC_ACC
     uint32 collect(uint32 bytes){
       return bytes;
     }
 
-    MAMC_ACCELERATOR
+    MAMC_ACC
     void* distribute(void* allocatedMem){
       return allocatedMem;
     }
 
+    MAMC_HOST
     static std::string classname(){
       return "Noop";
     }

--- a/thirdParty/mallocMC/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/distributionPolicies/XMallocSIMD_impl.hpp
@@ -82,7 +82,7 @@ namespace DistributionPolicies{
     public:
       static const uint32 _pagesize = pagesize;
 
-      MAMC_ACCELERATOR
+      MAMC_ACC_CUDA_ONLY
       uint32 collect(uint32 bytes){
 
         can_use_coalescing = false;
@@ -113,7 +113,7 @@ namespace DistributionPolicies{
       }
 
 
-      MAMC_ACCELERATOR
+      MAMC_ACC_CUDA_ONLY
       void* distribute(void* allocatedMem){
         __shared__ char* warp_res[32];
 

--- a/thirdParty/mallocMC/src/include/mallocMC/mallocMC_hostclass.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/mallocMC_hostclass.hpp
@@ -77,8 +77,9 @@ namespace mallocMC{
     template<typename T_ProvidesAvailableSlotsHost>
     struct GetAvailableSlotsIfAvail
     {
+      MAMC_NO_HOST_ACC_WARNING
       template<typename T_Allocator>
-      MAMC_HOST MAMC_ACCELERATOR
+      MAMC_ACC
       static unsigned getAvailableSlots(size_t slotSize, T_Allocator &){
         return 0;
       }
@@ -87,8 +88,9 @@ namespace mallocMC{
     struct GetAvailableSlotsIfAvail<
       boost::mpl::bool_<true> >
     {
+      MAMC_NO_HOST_ACC_WARNING
       template<typename T_Allocator>
-      MAMC_HOST MAMC_ACCELERATOR
+      MAMC_ACC
       static unsigned getAvailableSlots(size_t slotSize, T_Allocator & alloc){
 #ifdef __CUDA_ARCH__
         return alloc.getAvailableSlotsAccelerator(slotSize);
@@ -147,7 +149,8 @@ namespace mallocMC{
       typedef Allocator<CreationPolicy,DistributionPolicy,
               OOMPolicy,ReservePoolPolicy,AlignmentPolicy> MyType;
 
-      MAMC_ACCELERATOR
+      MAMC_NO_HOST_ACC_WARNING
+      MAMC_ACC
       void* alloc(size_t bytes){
         DistributionPolicy distributionPolicy;
 
@@ -164,7 +167,8 @@ namespace mallocMC{
         // }
       }
 
-      MAMC_ACCELERATOR
+      MAMC_NO_HOST_ACC_WARNING
+      MAMC_ACC
       void dealloc(void* p){
         CreationPolicy::destroy(p);
       }
@@ -212,7 +216,8 @@ namespace mallocMC{
 
 
       // polymorphism over the availability of getAvailableSlots
-      MAMC_HOST MAMC_ACCELERATOR
+      MAMC_NO_HOST_ACC_WARNING
+      MAMC_ACC
       unsigned getAvailableSlots(size_t slotSize){
         slotSize = AlignmentPolicy::applyPadding(slotSize);
 

--- a/thirdParty/mallocMC/src/include/mallocMC/mallocMC_prefixes.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/mallocMC_prefixes.hpp
@@ -29,14 +29,19 @@
 
 #pragma once
 
-#pragma once
-
-
-#if defined(__CUDACC__)
-
+#if defined(MAMC_CUDA_ENABLED) && defined(__CUDACC__)
     #define MAMC_HOST __host__
-    #define MAMC_ACCELERATOR __device__
+    #define MAMC_ACC __host__ __device__
+    #define MAMC_ACC_CUDA_ONLY __device__
 #else
     #define MAMC_HOST
-    #define MAMC_ACCELERATOR
+    #define MAMC_ACC
+    //#define MAMC_ACC_CUDA_ONLY
+#endif
+
+#if defined(MAMC_CUDA_ENABLED) && defined(__CUDACC__)
+    #define MAMC_NO_HOST_ACC_WARNING\
+        _Pragma("hd_warning_disable")
+#else
+    #define MAMC_NO_HOST_ACC_WARNING
 #endif

--- a/thirdParty/mallocMC/src/include/mallocMC/mallocMC_utils.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/mallocMC_utils.hpp
@@ -51,6 +51,7 @@ namespace CUDA
   class error : public std::runtime_error
   {
   private:
+    MAMC_HOST
     static std::string genErrorString(cudaError error, const char* file, int line)
     {
       std::ostringstream msg;
@@ -58,22 +59,26 @@ namespace CUDA
       return msg.str();
     }
   public:
+    MAMC_HOST
     error(cudaError error, const char* file, int line)
       : runtime_error(genErrorString(error, file, line))
     {
     }
 
+    MAMC_HOST
     error(cudaError error)
       : runtime_error(cudaGetErrorString(error))
     {
     }
 
+    MAMC_HOST
     error(const std::string& msg)
       : runtime_error(msg)
     {
     }
   };
 
+  MAMC_HOST
   inline void checkError(cudaError error, const char* file, int line)
   {
 #ifdef _DEBUG
@@ -82,11 +87,13 @@ namespace CUDA
 #endif
   }
 
+  MAMC_HOST
   inline void checkError(const char* file, int line)
   {
     checkError(cudaGetLastError(), file, line);
   }
 
+  MAMC_HOST
   inline void checkError()
   {
 #ifdef _DEBUG
@@ -132,68 +139,68 @@ namespace mallocMC
   typedef mallocMC::__PointerEquivalent<sizeof(char*)>::type PointerEquivalent;
 
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch laneid()
+  MAMC_ACC_CUDA_ONLY inline uint32_richtig_huebsch laneid()
   {
     uint32_richtig_huebsch mylaneid;
     asm("mov.u32 %0, %laneid;" : "=r" (mylaneid));
     return mylaneid;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch warpid()
+  MAMC_ACC_CUDA_ONLY inline uint32_richtig_huebsch warpid()
   {
     uint32_richtig_huebsch mywarpid;
     asm("mov.u32 %0, %warpid;" : "=r" (mywarpid));
     return mywarpid;
   }
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch nwarpid()
+  MAMC_ACC_CUDA_ONLY inline uint32_richtig_huebsch nwarpid()
   {
     uint32_richtig_huebsch mynwarpid;
     asm("mov.u32 %0, %nwarpid;" : "=r" (mynwarpid));
     return mynwarpid;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch smid()
+  MAMC_ACC_CUDA_ONLY inline uint32_richtig_huebsch smid()
   {
     uint32_richtig_huebsch mysmid;
     asm("mov.u32 %0, %smid;" : "=r" (mysmid));
     return mysmid;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch nsmid()
+  MAMC_ACC_CUDA_ONLY inline uint32_richtig_huebsch nsmid()
   {
     uint32_richtig_huebsch mynsmid;
     asm("mov.u32 %0, %nsmid;" : "=r" (mynsmid));
     return mynsmid;
   }
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch lanemask()
+  MAMC_ACC_CUDA_ONLY inline uint32_richtig_huebsch lanemask()
   {
     uint32_richtig_huebsch lanemask;
     asm("mov.u32 %0, %lanemask_eq;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch lanemask_le()
+  MAMC_ACC_CUDA_ONLY inline uint32_richtig_huebsch lanemask_le()
   {
     uint32_richtig_huebsch lanemask;
     asm("mov.u32 %0, %lanemask_le;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch lanemask_lt()
+  MAMC_ACC_CUDA_ONLY inline uint32_richtig_huebsch lanemask_lt()
   {
     uint32_richtig_huebsch lanemask;
     asm("mov.u32 %0, %lanemask_lt;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch lanemask_ge()
+  MAMC_ACC_CUDA_ONLY inline uint32_richtig_huebsch lanemask_ge()
   {
     uint32_richtig_huebsch lanemask;
     asm("mov.u32 %0, %lanemask_ge;" : "=r" (lanemask));
     return lanemask;
   }
 
-  MAMC_ACCELERATOR inline uint32_richtig_huebsch lanemask_gt()
+  MAMC_ACC_CUDA_ONLY inline uint32_richtig_huebsch lanemask_gt()
   {
     uint32_richtig_huebsch lanemask;
     asm("mov.u32 %0, %lanemask_gt;" : "=r" (lanemask));
@@ -201,7 +208,7 @@ namespace mallocMC
   }
 
   template<class T>
-  MAMC_HOST MAMC_ACCELERATOR inline T divup(T a, T b) { return (a + b - 1)/b; }
+  MAMC_ACC inline T divup(T a, T b) { return (a + b - 1)/b; }
 
 }
 

--- a/thirdParty/mallocMC/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/oOMPolicies/BadAllocException_impl.hpp
@@ -38,7 +38,7 @@ namespace OOMPolicies{
 
   struct BadAllocException
   {
-    MAMC_ACCELERATOR
+    MAMC_ACC
     static void* handleOOM(void* mem){
 #ifdef __CUDACC__
 //#if __CUDA_ARCH__ < 350
@@ -56,6 +56,7 @@ namespace OOMPolicies{
       return mem;
     }
 
+    MAMC_HOST
     static std::string classname(){
       return "BadAllocException";
     }

--- a/thirdParty/mallocMC/src/include/mallocMC/oOMPolicies/ReturnNull_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/oOMPolicies/ReturnNull_impl.hpp
@@ -38,11 +38,12 @@ namespace OOMPolicies{
   class ReturnNull
   {
     public:
-      MAMC_ACCELERATOR
+      MAMC_ACC
       static void* handleOOM(void* mem){
         return NULL;
       }
 
+      MAMC_HOST
       static std::string classname(){
         return "ReturnNull";
       }

--- a/thirdParty/mallocMC/src/include/mallocMC/reservePoolPolicies/CudaSetLimits_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/reservePoolPolicies/CudaSetLimits_impl.hpp
@@ -36,15 +36,18 @@ namespace mallocMC{
 namespace ReservePoolPolicies{
 
   struct CudaSetLimits{
+    MAMC_HOST
     static void* setMemPool(size_t memsize){
       cudaDeviceSetLimit(cudaLimitMallocHeapSize, memsize);
       return NULL;
     }
 
+    MAMC_HOST
     static void resetMemPool(void *p=NULL){
       cudaDeviceSetLimit(cudaLimitMallocHeapSize, 8192U);
     }
 
+    MAMC_HOST
     static std::string classname(){
       return "CudaSetLimits";
     }

--- a/thirdParty/mallocMC/src/include/mallocMC/reservePoolPolicies/NoOp.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/reservePoolPolicies/NoOp.hpp
@@ -33,9 +33,7 @@ namespace ReservePoolPolicies{
   /**
    * @brief Does not reserve any memory or set any heap limit.
    *
-   * This ReservePoolPolicy is intended for use with host pools It should be used in
-   * conjunction with a CreationPolicy that actually requires the CUDA-internal
-   * heap to be sized by calls to cudaDeviceSetLimit()
+   * This ReservePoolPolicy is intended for memory allocations without pool.
    */
   struct NoOp;
 

--- a/thirdParty/mallocMC/src/include/mallocMC/reservePoolPolicies/NoOp_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/reservePoolPolicies/NoOp_impl.hpp
@@ -35,13 +35,16 @@ namespace mallocMC{
 namespace ReservePoolPolicies{
 
   struct NoOp{
+    MAMC_ACC
     static void* setMemPool(size_t memsize){
       return NULL;
     }
 
+    MAMC_ACC
     static void resetMemPool(void *p=NULL){
     }
 
+    MAMC_HOST
     static std::string classname(){
       return "NoOp";
     }

--- a/thirdParty/mallocMC/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc_impl.hpp
+++ b/thirdParty/mallocMC/src/include/mallocMC/reservePoolPolicies/SimpleCudaMalloc_impl.hpp
@@ -37,16 +37,19 @@ namespace mallocMC{
 namespace ReservePoolPolicies{
 
   struct SimpleCudaMalloc{
+    MAMC_HOST
     static void* setMemPool(size_t memsize){
       void* pool;
       MALLOCMC_CUDA_CHECKED_CALL(cudaMalloc(&pool, memsize));
       return pool;
     }
 
+    MAMC_HOST
     static void resetMemPool(void* p){
       MALLOCMC_CUDA_CHECKED_CALL(cudaFree(p));
     }
 
+    MAMC_HOST
     static std::string classname(){
       return "SimpleCudaMalloc";
     }


### PR DESCRIPTION
- use plain old pointers linke in the original code
- make `CudaEvent` copyable
